### PR TITLE
Fixing bug in pull request 2: LULESH hangs in failure runs

### DIFF
--- a/lulesh2_resilient/src/DomainSnapshot.x10
+++ b/lulesh2_resilient/src/DomainSnapshot.x10
@@ -18,7 +18,7 @@ class DomainSnapshot implements Cloneable {
     public def this(domain:Domain) {
         val numNode = domain.x.size as Long;
         val numElem = domain.e.size as Long;        
-        data = new Rail[Double](6*numNode + 6*numElem + 7);
+        data = new Rail[Double](6*numNode + 6*numElem + 8);
         var srcOff:Long = 0;
         data(srcOff++) = numNode;
         data(srcOff++) = numElem;
@@ -27,6 +27,7 @@ class DomainSnapshot implements Cloneable {
         data(srcOff++) = domain.dthydro;
         data(srcOff++) = domain.cycle;
         data(srcOff++) = domain.time;
+        data(srcOff++) = domain.deltatime;
         
         data(srcOff++) = domain.startTimeMillis;
         
@@ -63,6 +64,7 @@ class DomainSnapshot implements Cloneable {
         domain.dthydro = data(srcOff++);
         domain.cycle = data(srcOff++) as Int;
         domain.time = data(srcOff++);
+        domain.deltatime = data(srcOff++);
         
         domain.startTimeMillis = data(srcOff++) as Long;
         

--- a/lulesh2_resilient/src/Lulesh.x10
+++ b/lulesh2_resilient/src/Lulesh.x10
@@ -57,7 +57,7 @@ public final class Lulesh implements SPMDResilientIterativeApp {
     static SYNCH_GHOST_EXCHANGE = System.getenv("LULESH_SYNCH_GHOSTS") != null;
 
     /** The simulation domain at each place. */
-    protected val domainPlh:PlaceLocalHandle[Domain];
+    protected var domainPlh:PlaceLocalHandle[Domain];
 
     /** Manager for nodal mass updates between all neighbors */
     protected var massGhostMgr:GhostManager;
@@ -295,11 +295,9 @@ public final class Lulesh implements SPMDResilientIterativeApp {
             throw new Exception("Num of restore processors must be a cube of an integer (1, 8, 27, ...)");
         }
         places = changes.newActivePlaces;
-        for (sparePlace in changes.addedPlaces){
-            PlaceLocalHandle.addPlace[Domain](
-                domainPlh, sparePlace, ()=>new Domain(opts.nx, opts.numReg, opts.balance, opts.cost, placesPerSide, places.indexOf(here))
-            );
-        }
+        PlaceLocalHandle.destroy(changes.oldActivePlaces, domainPlh, (Place)=>true);
+        domainPlh = PlaceLocalHandle.make[Domain](places,
+                () => new Domain(opts.nx, opts.numReg, opts.balance, opts.cost, placesPerSide, places.indexOf(here)));
         remakeDomainTime += Timer.milliTime();
         
         this.team = newTeam;

--- a/lulesh2_resilient/src/Lulesh.x10
+++ b/lulesh2_resilient/src/Lulesh.x10
@@ -57,7 +57,7 @@ public final class Lulesh implements SPMDResilientIterativeApp {
     static SYNCH_GHOST_EXCHANGE = System.getenv("LULESH_SYNCH_GHOSTS") != null;
 
     /** The simulation domain at each place. */
-    protected var domainPlh:PlaceLocalHandle[Domain];
+    protected val domainPlh:PlaceLocalHandle[Domain];
 
     /** Manager for nodal mass updates between all neighbors */
     protected var massGhostMgr:GhostManager;
@@ -295,9 +295,9 @@ public final class Lulesh implements SPMDResilientIterativeApp {
             throw new Exception("Num of restore processors must be a cube of an integer (1, 8, 27, ...)");
         }
         places = changes.newActivePlaces;
-        PlaceLocalHandle.destroy(changes.oldActivePlaces, domainPlh, (Place)=>true);
-        domainPlh = PlaceLocalHandle.make[Domain](places,
-                () => new Domain(opts.nx, opts.numReg, opts.balance, opts.cost, placesPerSide, places.indexOf(here)));
+        for (sparePlace in changes.addedPlaces){
+            PlaceLocalHandle.addPlace[Domain](domainPlh, sparePlace, ()=>new Domain(opts.nx, opts.numReg, opts.balance, opts.cost, placesPerSide, places.indexOf(here)));
+        }
         remakeDomainTime += Timer.milliTime();
         
         this.team = newTeam;


### PR DESCRIPTION
Before pull request 2, the remake method was creating new Domain objects
at all places. This was modified in pull request 2 by initializing new
places only; other places reused their Domain object. This caused a bug; after recovery, Domain.time was not equivalent at all places, causing old places to terminate before newly added places.

By reinitializing Domain.time at all places, they all terminate at the same time at expense of running more steps than in a failure-free scenario.