### PR TITLE
Resilient LULESH bug fixes

### DIFF
--- a/lulesh2_resilient/src/GhostManager.x10
+++ b/lulesh2_resilient/src/GhostManager.x10
@@ -359,6 +359,8 @@ public final class GhostManager {
             // (c) get the packed data from my neighbors
             finish {
                 for (i in ls.neighborListRecv.range) {
+                	if (ls.remoteSendBuffers(i).home().isDead())
+                		throw new DeadPlaceException(ls.remoteSendBuffers(i).home(), "Source place["+ls.remoteSendBuffers(i).home()+"] died before asyncCopy operation");
                     Rail.asyncCopy(ls.remoteSendBuffers(i), 0, ls.recvBuffers(i), 0, ls.recvBuffers(i).size);
                 }
             }
@@ -374,7 +376,6 @@ public final class GhostManager {
             checkException(e);
         }
     }
-
 
    /**
      * Update boundary data at all neighboring places, overwriting with data
@@ -443,6 +444,8 @@ public final class GhostManager {
             // (c) get the packed data from my neighbors
             finish {
                 for (i in ls.neighborListRecv.range) {
+                	if (ls.remoteSendBuffers(i).home().isDead())
+                		throw new DeadPlaceException(ls.remoteSendBuffers(i).home(), "Source place["+ls.remoteSendBuffers(i).home()+"] died before asyncCopy operation");
                     Rail.asyncCopy(ls.remoteSendBuffers(i), 0, ls.recvBuffers(i), 0, ls.recvBuffers(i).size);
                 }
             }
@@ -535,6 +538,8 @@ public final class GhostManager {
             // (c) get the packed data from my neighbors
             finish {
                 for (i in ls.neighborListRecv.range) {
+                	if (ls.remoteSendBuffers(i).home().isDead())
+                		throw new DeadPlaceException(ls.remoteSendBuffers(i).home(), "Source place["+ls.remoteSendBuffers(i).home()+"] died before asyncCopy operation");
                     Rail.asyncCopy(ls.remoteSendBuffers(i), 0, ls.recvBuffers(i), 0, ls.recvBuffers(i).size);
                 }
             }

--- a/lulesh2_resilient/src/Lulesh.x10
+++ b/lulesh2_resilient/src/Lulesh.x10
@@ -95,6 +95,11 @@ public final class Lulesh implements SPMDResilientIterativeApp {
             System.setExitCode(EXIT_CODE_INCORRECT_USAGE);
             return;
         }
+        if (!SYNCH_GHOST_EXCHANGE && x10.xrx.Runtime.RESILIENT_MODE > 0) {
+        	Console.ERR.println("Must set LULESH_SYNCH_GHOSTS=1 in resilient mode");
+        	System.setExitCode(EXIT_CODE_INCORRECT_USAGE);
+            return;
+        }
         
         val startTime = Timer.milliTime();
         val executor = new SPMDResilientIterativeExecutor(opts.checkpointFreq, opts.spare, false, true);


### PR DESCRIPTION
Fixing bugs to avoid hanging when places die at random times (i.e. using KILL_TIMES, rather than KILL_STEPS in the iterative framework):
- DPE during ghost cells exchange are suppressed to ensure that all active places participate in next collectives which will eventually fail at all places.
- Avoid initiating Rail.asyncCopy from a place that is known to be dead. These get requests will hang and GetRegistry.notifyPlaceDeath() won't release them, as it is called once for each place failure event.